### PR TITLE
refactor: externalize MTN credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,10 @@ PRIVATE_KEY_PATH= /var/www/vhosts/xo-textile.sy/private_key.pem
 
 PUBLIC_KEY_PATH= /var/www/vhosts/xo-textile.sy/public_key.pem
 
+MTN_SECRET=
+MTN_SERIAL=
+MTN_QR=
+
 
 VITE_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
 VITE_PUSHER_HOST="${PUSHER_HOST}"

--- a/app/Http/Controllers/MTNPaymentController.php
+++ b/app/Http/Controllers/MTNPaymentController.php
@@ -88,7 +88,7 @@ class MTNPaymentController extends Controller
                 'headers' => [
                     'Request-Name' => 'pos_web/payment_phone/confirm',
                     'X-Signature' => $encryptedString,
-                    'Subject' => '9001000000048983',
+                    'Subject' => config('app.MTN_SERIAL'),
                     'Accept-Language' => 'en'
                 ],
                 'json' => [
@@ -313,8 +313,8 @@ return response()->error(['message' => 'Something went processing'],400);
 
 
         $jsonBody = [
-            'Secret' => "18263555",
-            'Serial' => "9001000000048983",
+            'Secret' => config('app.MTN_SECRET'),
+            'Serial' => config('app.MTN_SERIAL'),
             'Key' => $publicKey
         ];
 
@@ -337,12 +337,12 @@ return response()->error(['message' => 'Something went processing'],400);
             'headers' => [
                 'Request-Name' => 'pos_web/pos/activate',
                 'X-Signature' => $encryptedString,
-                'Subject' => "9001000000048983",
+                'Subject' => config('app.MTN_SERIAL'),
                 'Accept-Language' => 'en'
             ],
             'json' => [
-                'Secret' => "18263555",
-                'Serial' => "9001000000048983",
+                'Secret' => config('app.MTN_SECRET'),
+                'Serial' => config('app.MTN_SERIAL'),
                 'Key' => $publicKey
             ],
             'stream' => false,
@@ -418,7 +418,7 @@ return response()->error(['message' => 'Something went processing'],400);
             'headers' => [
                 'Request-Name' => 'pos_web/payment_phone/initiate',
                 'X-Signature' => $encryptedString,
-                'Subject' => '9001000000048983',
+                'Subject' => config('app.MTN_SERIAL'),
                 'Accept-Language' => 'en'
             ],
             'json' => [
@@ -567,7 +567,7 @@ return response()->error(['message' => 'Something went processing'],400);
             'headers' => [
                 'Request-Name' => 'pos_web/invoice/create',
                 'X-Signature' => $encryptedString,
-                'Subject' => '9001000000048983',
+                'Subject' => config('app.MTN_SERIAL'),
                 'Accept-Language' => 'en'
             ],
             'json' => [
@@ -620,7 +620,7 @@ return response()->error(['message' => 'Something went processing'],400);
             'headers' => [
                 'Request-Name' => 'pos_web/invoice/refund/initiate',
                 'X-Signature' => $encryptedString,
-                'Subject' => '9001000000048983',
+                'Subject' => config('app.MTN_SERIAL'),
                 'Accept-Language' => 'en'
             ],
             'json' => [
@@ -669,7 +669,7 @@ return response()->error(['message' => 'Something went processing'],400);
             'headers' => [
                 'Request-Name' => 'pos_web/invoice/refund/confirm',
                 'X-Signature' => $encryptedString,
-                'Subject' => '9001000000048983',
+                'Subject' => config('app.MTN_SERIAL'),
                 'Accept-Language' => 'en'
             ],
             'json' => [
@@ -718,7 +718,7 @@ return response()->error(['message' => 'Something went processing'],400);
             'headers' => [
                 'Request-Name' => 'pos_web/invoice/refund/confirm',
                 'X-Signature' => $encryptedString,
-                'Subject' => '9001000000048983',
+                'Subject' => config('app.MTN_SERIAL'),
                 'Accept-Language' => 'en'
             ],
             'json' => [

--- a/app/Http/Controllers/MTNPaymentTestController.php
+++ b/app/Http/Controllers/MTNPaymentTestController.php
@@ -74,7 +74,7 @@ class MTNPaymentTestController extends Controller
                 'headers' => [
                     'Request-Name' => 'pos_web/payment_phone/confirm',
                     'X-Signature' => $encryptedString,
-                    'Subject' => '9001000000048983',
+                    'Subject' => config('app.MTN_SERIAL'),
                     'Accept-Language' => 'en'
                 ],
                 'json' => [
@@ -304,8 +304,8 @@ return response()->error(['message' => 'Something went processing'],400);
 
 
         $jsonBody = [
-            'Secret' => "18263555",
-            'Serial' => "9001000000048983",
+            'Secret' => config('app.MTN_SECRET'),
+            'Serial' => config('app.MTN_SERIAL'),
             'Key' => $publicKey
         ];
 
@@ -328,12 +328,12 @@ return response()->error(['message' => 'Something went processing'],400);
             'headers' => [
                 'Request-Name' => 'pos_web/pos/activate',
                 'X-Signature' => $encryptedString,
-                'Subject' => "9001000000048983",
+                'Subject' => config('app.MTN_SERIAL'),
                 'Accept-Language' => 'en'
             ],
             'json' => [
-                'Secret' => "18263555",
-                'Serial' => "9001000000048983",
+                'Secret' => config('app.MTN_SECRET'),
+                'Serial' => config('app.MTN_SERIAL'),
                 'Key' => $publicKey
             ],
             'stream' => false,
@@ -375,7 +375,7 @@ return response()->error(['message' => 'Something went processing'],400);
             "Errno" => 0,
             "Receipt"=> [
                 "Invoice"=> 25666,
-                "Pos"=> 9001000000048983,
+                "Pos"=> config('app.MTN_SERIAL'),
                 "Session"=> 0,
                 "Status"=> 1,
                 "Amount"=> 100000,
@@ -387,7 +387,7 @@ return response()->error(['message' => 'Something went processing'],400);
                 "Processed"=> -62135596800,
                 "Commission"=> 0,
                 "Tax"=> 0,
-                "Qr"=> "MTN-M-9001000000048983-25666-3045022100EB6D8414D2DC5B6C460B8D5AFABE59417A4FFDD56DD017F16A6780D6A98C3172022012979E83A9B78227A6F5F4DAABEB4F88D077BB9880DBA515DB2D4D68F6A5AF9D",
+                "Qr"=> config('app.MTN_QR'),
                 "Currency"=> 0,
                 "Description"=> "Merchant QR payment",
                 "ReceiptError"=> [
@@ -441,7 +441,7 @@ return response()->error(['message' => 'Something went processing'],400);
             'headers' => [
                 'Request-Name' => 'pos_web/payment_phone/initiate',
                 'X-Signature' => $encryptedString,
-                'Subject' => '9001000000048983',
+                'Subject' => config('app.MTN_SERIAL'),
                 'Accept-Language' => 'en'
             ],
             'json' => [
@@ -593,7 +593,7 @@ return response()->error(['message' => 'Something went processing'],400);
             'headers' => [
                 'Request-Name' => 'pos_web/invoice/create',
                 'X-Signature' => $encryptedString,
-                'Subject' => '9001000000048983',
+                'Subject' => config('app.MTN_SERIAL'),
                 'Accept-Language' => 'en'
             ],
             'json' => [
@@ -646,7 +646,7 @@ return response()->error(['message' => 'Something went processing'],400);
             'headers' => [
                 'Request-Name' => 'pos_web/invoice/refund/initiate',
                 'X-Signature' => $encryptedString,
-                'Subject' => '9001000000048983',
+                'Subject' => config('app.MTN_SERIAL'),
                 'Accept-Language' => 'en'
             ],
             'json' => [
@@ -695,7 +695,7 @@ return response()->error(['message' => 'Something went processing'],400);
             'headers' => [
                 'Request-Name' => 'pos_web/invoice/refund/confirm',
                 'X-Signature' => $encryptedString,
-                'Subject' => '9001000000048983',
+                'Subject' => config('app.MTN_SERIAL'),
                 'Accept-Language' => 'en'
             ],
             'json' => [
@@ -744,7 +744,7 @@ return response()->error(['message' => 'Something went processing'],400);
             'headers' => [
                 'Request-Name' => 'pos_web/invoice/refund/confirm',
                 'X-Signature' => $encryptedString,
-                'Subject' => '9001000000048983',
+                'Subject' => config('app.MTN_SERIAL'),
                 'Accept-Language' => 'en'
             ],
             'json' => [

--- a/app/Services/MTNCashService.php
+++ b/app/Services/MTNCashService.php
@@ -63,7 +63,7 @@ class MTNCashService
                 'headers' => [
                     'Request-Name' => 'pos_web/payment_phone/initiate',
                     'X-Signature' => $encryptedString,
-                    'Subject' => '9001000000048983',
+                    'Subject' => config('app.MTN_SERIAL'),
                     'Accept-Language' => 'en'
                 ],
                 'json' => [
@@ -118,8 +118,8 @@ class MTNCashService
 
 
         $jsonBody =  [
-            'Secret' => "18263555",
-            'Serial' => "9001000000048983",
+            'Secret' => config('app.MTN_SECRET'),
+            'Serial' => config('app.MTN_SERIAL'),
             'Key' =>   $publicKey
         ];
 
@@ -142,12 +142,12 @@ class MTNCashService
             'headers' => [
                 'Request-Name' => 'pos_web/pos/activate',
                 'X-Signature' => $encryptedString,
-                'Subject' => "9001000000048983",
+                'Subject' => config('app.MTN_SERIAL'),
                 'Accept-Language' => 'en'
             ],
             'json' => [
-                'Secret' => "18263555",
-                'Serial' => "9001000000048983",
+                'Secret' => config('app.MTN_SECRET'),
+                'Serial' => config('app.MTN_SERIAL'),
                 'Key' =>   $publicKey
             ],
             'stream' => false,
@@ -198,7 +198,7 @@ class MTNCashService
             'headers' => [
                 'Request-Name' => 'pos_web/payment_phone/initiate',
                 'X-Signature' => $encryptedString,
-                'Subject' => '9001000000048983',
+                'Subject' => config('app.MTN_SERIAL'),
                 'Accept-Language' => 'en'
             ],
             'json' => [
@@ -234,7 +234,7 @@ class MTNCashService
     {
 
 
-        $amount = isset($request->validated('Amount')) ? $request->validated('Amount') * 100 : ($request->header('X-Amount') * 100);
+        $amount = $request->validated('Amount') !== null ? $request->validated('Amount') * 100 : ($request->header('X-Amount') * 100);
 
 
         $invoice_number = rand(10000, 99999);
@@ -280,7 +280,7 @@ class MTNCashService
             'headers' => [
                 'Request-Name' => 'pos_web/invoice/create',
                 'X-Signature' => $encryptedString,
-                'Subject' => '9001000000048983',
+                'Subject' => config('app.MTN_SERIAL'),
                 'Accept-Language' => 'en'
             ],
             'json' => [

--- a/config/app.php
+++ b/config/app.php
@@ -65,6 +65,10 @@ return [
     'TWILIO_SID' => env('TWILIO_SID'),
     'TWILIO_VERIFY_SID' => env('TWILIO_VERIFY_SID'),
 
+    'MTN_SECRET' => env('MTN_SECRET'),
+    'MTN_SERIAL' => env('MTN_SERIAL'),
+    'MTN_QR' => env('MTN_QR'),
+
     'ecash_base_url' => env('ecash_base_url'),
     'ecash_terminal_key' => env('ecash_terminal_key'),
     'ecash_merchant_id' => env('ecash_merchant_id'),


### PR DESCRIPTION
## Summary
- remove hard-coded MTN credentials from controllers and services
- load MTN secret, serial, and QR code from environment configuration

## Testing
- `php -l config/app.php`
- `php -l app/Services/MTNCashService.php`
- `php -l app/Http/Controllers/MTNPaymentController.php`
- `php -l app/Http/Controllers/MTNPaymentTestController.php`
- `composer install` *(fails: lock file requires older PHP version)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a4ad34f48333abaa37c152cb6099